### PR TITLE
Fix title size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <img src="https://avatars3.githubusercontent.com/u/12463357?v=3" />
+
 # docker-elasticfence
 Docker container running the Elasticfence Stack
 


### PR DESCRIPTION
Apparently the Markdown parser in Github needs a new line to parse properly header lines. 